### PR TITLE
Address list_display and fieldsets in admin docs

### DIFF
--- a/docs/admin.txt
+++ b/docs/admin.txt
@@ -2,13 +2,39 @@ Using tags in the admin
 =======================
 
 By default if you have a :class:`TaggableManager` on your model it will show up
-in the admin, just as it will in any other form.  One important thing to note
-is that you *cannot* include a :class:`TaggableManager` in
-:attr:`ModelAdmin.list_display`, if you do you'll see an exception that looks
+in the admin, just as it will in any other form.
+
+If you are specifying :attr:`ModelAdmin.fieldsets`, include the name
+of the :class:`TaggableManager` as a field::
+
+    fieldsets = (
+        (None, {'fields': ('tags')}),
+    )
+
+Including tags in :attr:`ModelAdmin.list_display`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+One important thing to note is that you *cannot* include a :class:`TaggableManager` 
+in :attr:`ModelAdmin.list_display`. If you do you'll see an exception that looks
 like::
 
-    AttributeError: 'TaggableManager' object has no attribute 'flatchoices'
+    AttributeError: '_TaggableManager' object has no attribute 'name'
 
-This is for the same reason that you cannot include a :class:`ManyToManyField`,
-it would result in an unreasonable number of queries being executed.  If you really would like to add it, you can read the
+This is for the same reason that you cannot include a :class:`ManyToManyField`:
+it would result in an unreasonable number of queries being executed.
+
+If you want to show tags in :attr:`ModelAdmin.list_display`, you can add a
+custom display method to the :class:`ModelAdmin`, using ``prefetch_related`` to
+minimize queries::
+
+    class MyModelAdmin(admin.ModelAdmin):
+        list_display = ['tag_list']
+    
+        def get_queryset(self, request):
+            return super(MyModelAdmin, self).get_queryset(request).prefetch_related('tags')
+
+        def tag_list(self, obj):
+            return u", ".join(o.name for o in obj.tags.all())
+
+For details, see the
 `Django documentation <http://docs.djangoproject.com/en/1.8/ref/contrib/admin/#django.contrib.admin.ModelAdmin.list_display>`_.


### PR DESCRIPTION
A couple of additions to the docs for the Django admin -- explain how to include tags in `fieldsets`, and provide a sample ModelAdmin that efficiently includes a list of tags in `list_display`.
